### PR TITLE
[ refactor ] using a universe to clean up show's constraints

### DIFF
--- a/examples/Parametrized.agda
+++ b/examples/Parametrized.agda
@@ -31,7 +31,7 @@ module Nat where
   elimℕ P H0 Hn n = elim″ natHasDesc P H0 Hn n
 
   showℕ : ℕ → String
-  showℕ = show natHasDesc (tt , tt , tt)
+  showℕ = show natHasDesc tt
 
   decℕ : DecEq ℕ
   decℕ = ≡-dec natHasDesc (tt , ((tt , tt) , tt))
@@ -63,9 +63,7 @@ module Vek where
   -- t = elim″ vekHasDesc P {!!} λ x g Pg → {!!}
 
   showV : {A : Set} → (A → String) → ∀ {n} → vek A n → String
-  showV showA =
-    show vekHasDesc
-         (tt , ((Nat.showℕ , const (showA , const tt)) , tt))
+  showV showA = show vekHasDesc (Nat.showℕ , const (showA , const tt))
 
   decV : {A : Set} → (DecEq A) → ∀ {n} → DecEq (vek A n)
   decV decA =
@@ -101,7 +99,7 @@ module Id where
   idHasDesc = badconvert (testing Id)
 
   postulate P : {A : Set} {x y : A} → Id A x y → Set
-  
+
   -- t : ∀ {A} {x y : A} (p : Id A x y) → P p
   -- t = elim″ idHasDesc P {!!}
 
@@ -114,5 +112,5 @@ module Test {ℓ} where
 
   maybeHasDesc : HasDesc (Maybe {ℓ})
   maybeHasDesc = badconvert (testing Maybe)
-  
+
 -}

--- a/examples/Parametrized.agda
+++ b/examples/Parametrized.agda
@@ -31,7 +31,7 @@ module Nat where
   elimℕ P H0 Hn n = elim″ natHasDesc P H0 Hn n
 
   showℕ : ℕ → String
-  showℕ = show natHasDesc tt
+  showℕ = show natHasDesc
 
   decℕ : DecEq ℕ
   decℕ = ≡-dec natHasDesc (tt , ((tt , tt) , tt))


### PR DESCRIPTION
A quick and dirty demonstration. I have left the auxiliary definitions in the middle
of the file where I needed it but it should probably be moved to an auxiliary file.

As I was saying on zulip you could get even more mileage by distinguishing `π` (for
the natural number stored in a vector's cons) from `→` (for the `A` corresponding to
the vector's cons' head). Of course that comes at the price of having more constructors
to deal with when you write your generic operations. :(